### PR TITLE
fix: account for ngo with enum regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purify",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "main": "purify-cli.js",
   "repository": "git@github.com:IgorMinar/purify.git",
   "author": "Igor Minar <igor@angular.io>",

--- a/purify.js
+++ b/purify.js
@@ -15,8 +15,8 @@ module.exports = function(fileBody, fileName) {
       )
       /* wrap TS 2.3 enums w/ an IIFE */
       .replace(
-          /var (\S+);\n\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = 0\] = "\3";(\s+\1\[\1\["\S+"\] = \d\] = "\S+";)*\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/mg,
-          'var $1 = /*@__PURE__*/(function() {\n    var $1 = {};\n    $2    return $1;\n})();'
+          /var (\S+);(\/\*__PURE__\*\/)*\n\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = 0\] = "\4";(\s+\1\[\1\["\S+"\] = \d\] = "\S+";)*\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/mg,
+          'var $1 = /*@__PURE__*/(function() {\n    var $1 = {};\n    $3    return $1;\n})();'
       )
       /* Prefix safe imports with pure */
       .replace(


### PR DESCRIPTION
Ngo was adding a PURE prefix to the IIFE in the downleveled enum, so purify wasn't catching it properly. This PR updates the enum regex to account for this. 